### PR TITLE
Fix display menu

### DIFF
--- a/digigurdy-baz.ino
+++ b/digigurdy-baz.ino
@@ -1678,7 +1678,7 @@ void playing_options_screen() {
     my2Button->update();
     myBackButton->update();
 
-    if (myOkButton->wasPressed()) {
+    if (my1Button->wasPressed()) {
 
       play_screen_type = 0;
       EEPROM.write(EEPROM_DISPLY_TYPE, 0);


### PR DESCRIPTION
Display menu incorrectly checks for `myOkButton` rather than `my1Button` being pressed (as documented in menu text). This fixes that.

It has been tested on my instrument